### PR TITLE
Add Toolkit Labs Invoice to Freelancers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Field Team Management (5)](#field-team-management)
 - [field-team-management (4)](#field-team-management-1)
 - [Freelance & Consulting (11)](#freelance--consulting)
-- [Freelancers (8)](#freelancers)
+- [Freelancers (9)](#freelancers)
 - [Gamification (2)](#gamification)
 - [Global Team Practice (1)](#global-team-practice)
 - [Government (2)](#government)
@@ -2665,6 +2665,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Indy](https://weareindy.com) - All-in-one project management software for freelancers featuring hourly rate calculator, proposal and contract templates, time tracking, task management, and automated invoicing. ([Read more](/details/indy.md)) `Freelance` `Invoicing` `Contracts`
 - [Neon CRM](https://www.neonone.com/) - Comprehensive nonprofit management platform that integrates volunteer management with donor engagement, offering tools for recruiting, onboarding, scheduling, and tracking volunteer activities alongside fundraising capabilities. ([Read more](/details/neon-crm.md)) `Nonprofit` `Crm` `volunteer-management`
 - [Timecounts](https://www.timecounts.org/) - Modern volunteer management solution providing scheduling, hour tracking, communication, and impact reporting tools designed to help nonprofits maximize volunteer engagement and demonstrate program outcomes. ([Read more](/details/timecounts.md)) `volunteer-management` `Nonprofit` `Modern`
+- [Toolkit Labs Invoice](https://ytinumoc.github.io/toolkitlabs-invoice/) - Browser invoice and receipt generator for freelancers; fill seller, buyer, and line items, then print or save as PDF locally with no account. [Commercial white-label pack](https://buy.stripe.com/bJeeVea187TScZwb095Ne0k?client_reference_id=awesome-time-tracking-v1) (EUR 249 one-time) adds logo, colors, six templates, and unlimited batch CLI. ([Read more](/details/toolkitlabs-invoice.md)) `Free` `Invoicing` `Freelancers` `Pdf`
 - [TripLog](https://www.triplog.net/) - Automatic mileage tracker app that tracks business miles and expenses automatically, saving time and maximizing tax deductions. Features GPS-based automatic trip detection, receipt scanning, expense categorization, and IRS-compliant reporting for freelancers, businesses, and employees requiring mileage reimbursement. ([Read more](/details/triplog.md)) `Mileage Tracking` `Gps` `Automatic`
 - [Volgistics](https://www.volgistics.com/) - Comprehensive volunteer management software solution helping organizations coordinate volunteer schedules, track service hours, manage communications, and generate reports for thousands of volunteers efficiently. ([Read more](/details/volgistics.md)) `volunteer-management` `Nonprofit` `Cloud Based`
 - [Wave Accounting](https://www.waveapps.com/) - Free cloud-based accounting software for small businesses and freelancers, offering unlimited invoicing, receipt scanning, income and expense tracking, and financial reporting with optional paid add-ons for payments and payroll. ([Read more](/details/wave-accounting.md)) `Free` `Invoicing` `Accounting` `Small Business`

--- a/details/toolkitlabs-invoice.md
+++ b/details/toolkitlabs-invoice.md
@@ -1,0 +1,27 @@
+## Overview
+
+Toolkit Labs Invoice is a free browser-based invoice and receipt generator for freelancers and small businesses. Fill seller, buyer, and line items in the browser, then print or save as PDF locally — no account, upload, or subscription required.
+
+## Key Features
+
+**Free tier:**
+- Invoice and receipt generators in static HTML
+- Print or save as PDF from the browser
+- No signup, no data leaves the device unless you export
+
+**Commercial license (EUR 249 one-time):**
+- White-label PDFs with your logo and colors (no third-party footer)
+- Six templates: freelance, trades, rent, consulting, retail, retainer
+- Unlimited local batch via `invoice_batch.py` CLI and sample CSV
+- One business, commercial use — see LICENSE in zip
+
+## Pricing
+
+- **Free**: Full invoice/receipt generator at [ytinumoc.github.io/toolkitlabs-invoice](https://ytinumoc.github.io/toolkitlabs-invoice/)
+- **Commercial**: EUR 249 one-time via [Stripe payment link](https://buy.stripe.com/bJeeVea187TScZwb095Ne0k?client_reference_id=awesome-time-tracking-v1)
+
+## Best For
+
+- Freelancers who bill occasionally and want a simple PDF without SaaS lock-in
+- Shopkeepers and tradespeople who need branded invoices without monthly fees
+- Anyone replacing spreadsheet-to-PDF workflows with a one-click generator


### PR DESCRIPTION
## Summary
Adds [Toolkit Labs Invoice](https://ytinumoc.github.io/toolkitlabs-invoice/) to the Freelancers section.

- Free browser invoice/receipt generator — no account, print/save PDF locally
- Optional [Commercial white-label pack](https://buy.stripe.com/bJeeVea187TScZwb095Ne0k?client_reference_id=awesome-time-tracking-v1) (EUR 249 one-time): logo, colors, six templates, unlimited batch CLI

## Why
Freelancers who track time still need simple invoicing. This is a zero-signup alternative to monthly SaaS invoicing tools.

Made with [Cursor](https://cursor.com)